### PR TITLE
Memory efficient evaluation function

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 88
-ignore = E203, W503
+ignore = E203, W503, E731
 exclude = __init__.py

--- a/torchmps/mps_base.py
+++ b/torchmps/mps_base.py
@@ -41,7 +41,7 @@ from torchmps.utils2 import (
 TensorSeq = Union[Tensor, Sequence[Tensor]]
 
 
-def default_eval(seq_input: Tensor, core_tensor: Tensor, bound_vecs: Tensor) -> Tensor:
+def slim_eval(seq_input: Tensor, core_tensor: Tensor, bound_vecs: Tensor) -> Tensor:
     r"""
     Evaluate MPS tensor elements relative to a batch of sequential inputs.
 

--- a/torchmps/tests/benchmarks/test_benchmark_prob_mps.py
+++ b/torchmps/tests/benchmarks/test_benchmark_prob_mps.py
@@ -1,0 +1,159 @@
+# MIT License
+#
+# Copyright (c) 2021 Jacob Miller
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Tests for probabilistic MPS functions"""
+from functools import partial
+
+import torch
+
+from torchmps import ProbMPS, ProbUnifMPS
+from torchmps.tests.utils_for_tests import group_name
+
+
+def prob_eval_runner(
+    benchmark,
+    old_eval: bool = False,
+    vec_input: bool = False,
+    parallel: bool = False,
+    uniform: bool = True,
+    cmplx: bool = False,
+    input_dim: int = 10,
+    bond_dim: int = 10,
+    seq_len: int = 100,
+    batch: int = 100,
+):
+    # Initialize MPS model, fix evaluation style
+    if uniform:
+        mps_model = ProbUnifMPS(input_dim, bond_dim, cmplx, parallel)
+    else:
+        mps_model = ProbMPS(seq_len, input_dim, bond_dim, cmplx, parallel)
+    mps_model = partial(mps_model, fast_eval=old_eval)
+
+    # Create fake input data
+    if vec_input:
+        fake_data = torch.randn(seq_len, batch, input_dim).abs()
+        fake_data = fake_data / fake_data.sum(dim=-1, keepdim=True)
+    else:
+        fake_data = torch.randint(input_dim, (seq_len, batch))
+
+    # Benchmark get_mat_slices using input benchmark
+    benchmark(mps_model, fake_data)
+
+
+# Shorthand for old vs new evaluations
+old_eval_runner = partial(prob_eval_runner, fast_eval=True)
+new_eval_runner = partial(prob_eval_runner, fast_eval=False)
+
+
+@group_name("old_eval")
+def test_old_eval_base(benchmark):
+    """Benchmark old probabilistic evaluation with default values"""
+    old_eval_runner(benchmark)
+
+
+@group_name("new_eval")
+def test_new_eval_base(benchmark):
+    """Benchmark new probabilistic evaluation with default values"""
+    new_eval_runner(benchmark)
+
+
+@group_name("old_eval")
+def test_old_eval_nonuniform(benchmark):
+    """Benchmark old probabilistic evaluation with non-uniform core tensors"""
+    old_eval_runner(benchmark, uniform=False)
+
+
+@group_name("new_eval")
+def test_new_eval_nonuniform(benchmark):
+    """Benchmark new probabilistic evaluation with non-uniform core tensors"""
+    new_eval_runner(benchmark, uniform=False)
+
+
+@group_name("old_eval")
+def test_old_eval_complex(benchmark):
+    """Benchmark old probabilistic evaluation with complex core tensors"""
+    old_eval_runner(benchmark, cmplx=True)
+
+
+@group_name("new_eval")
+def test_new_eval_complex(benchmark):
+    """Benchmark new probabilistic evaluation with complex core tensors"""
+    new_eval_runner(benchmark, cmplx=True)
+
+
+@group_name("old_eval")
+def test_old_eval_large_seqlen(benchmark):
+    """Benchmark old probabilistic evaluation with 10x longer sequences"""
+    old_eval_runner(benchmark, seq_len=1000)
+
+
+@group_name("new_eval")
+def test_new_eval_large_seqlen(benchmark):
+    """Benchmark new probabilistic evaluation with 10x longer sequences"""
+    new_eval_runner(benchmark, seq_len=1000)
+
+
+@group_name("old_eval")
+def test_old_eval_vecs_in(benchmark):
+    """Benchmark old probabilistic evaluation with continuous inputs"""
+    old_eval_runner(benchmark, vec_input=True)
+
+
+@group_name("new_eval")
+def test_new_eval_vecs_in(benchmark):
+    """Benchmark new probabilistic evaluation with continuous inputs"""
+    new_eval_runner(benchmark, vec_input=True)
+
+
+@group_name("old_eval")
+def test_old_eval_large_bonddim(benchmark):
+    """Benchmark old probabilistic evaluation with 10x larger bond dimensions"""
+    old_eval_runner(benchmark, bond_dim=100)
+
+
+@group_name("new_eval")
+def test_new_eval_large_bonddim(benchmark):
+    """Benchmark new probabilistic evaluation with 10x larger bond dimensions"""
+    new_eval_runner(benchmark, bond_dim=100)
+
+
+@group_name("old_eval")
+def test_old_eval_large_inputdim(benchmark):
+    """Benchmark old probabilistic evaluation with 10x larger input dimensions"""
+    old_eval_runner(benchmark, input_dim=100)
+
+
+@group_name("new_eval")
+def test_new_eval_large_inputdim(benchmark):
+    """Benchmark new probabilistic evaluation with 10x larger input dimensions"""
+    new_eval_runner(benchmark, input_dim=100)
+
+
+@group_name("old_eval")
+def test_old_eval_extreme(benchmark):
+    """Benchmark old probabilistic evaluation with larger bond dims and seq lens"""
+    old_eval_runner(benchmark, bond_dim=100, seq_len=1000)
+
+
+@group_name("new_eval")
+def test_new_eval_extreme(benchmark):
+    """Benchmark new probabilistic evaluation with larger bond dims and seq lens"""
+    new_eval_runner(benchmark, bond_dim=100, seq_len=1000)

--- a/torchmps/tests/test_mps_base.py
+++ b/torchmps/tests/test_mps_base.py
@@ -31,7 +31,7 @@ from torchmps.mps_base import (
     contract_matseq,
     get_mat_slices,
     near_eye_init,
-    default_eval,
+    slim_eval,
 )
 from torchmps.utils2 import batch_broadcast, batch_to
 
@@ -174,11 +174,11 @@ def test_composite_init_mat_slice_contraction(
     target_prods = torch.eye(bond_dim)
     assert torch.allclose(prod_mats.abs(), target_prods)
 
-    # Do the same thing for default_eval, but with boundary vectors
+    # Do the same thing for slim_eval, but with boundary vectors
     ref_vec = torch.randn(bond_dim).to(core_tensor.dtype)
     ref_vals = ref_vec.norm() ** 2
     bound_vecs = torch.stack((ref_vec, ref_vec))
-    prod_vals = default_eval(fake_data, core_tensor, bound_vecs)
+    prod_vals = slim_eval(fake_data, core_tensor, bound_vecs)
     assert torch.allclose(prod_vals.abs(), ref_vals, atol=1e-4, rtol=1e-4)
 
 

--- a/torchmps/tests/test_prob_mps.py
+++ b/torchmps/tests/test_prob_mps.py
@@ -122,7 +122,7 @@ def test_model_forward(
         assert input_dim == 1
 
     # Check that the old method of evaluation gives identical results
-    old_log_probs = prob_mps(fake_data, old_eval=True)
+    old_log_probs = prob_mps(fake_data, fast_eval=True)
     assert torch.allclose(log_probs, old_log_probs)
 
 

--- a/torchmps/tests/test_prob_mps.py
+++ b/torchmps/tests/test_prob_mps.py
@@ -33,7 +33,7 @@ from .utils_for_tests import complete_binary_dataset, allcloseish
 bool_st = st.booleans
 seq_len_st = partial(st.integers, 1, 1000)
 bond_dim_st = partial(st.integers, 1, 20)
-input_dim_st = partial(st.integers, 1, 10)
+input_dim_st = partial(st.integers, 2, 10)
 model_list = ["fixed-len", "uniform"]
 
 
@@ -120,6 +120,10 @@ def test_model_forward(
     assert log_probs.is_floating_point()
     if not torch.all(log_probs <= 0):
         assert input_dim == 1
+
+    # Check that the old method of evaluation gives identical results
+    old_log_probs = prob_mps(fake_data, old_eval=True)
+    assert torch.allclose(log_probs, old_log_probs)
 
 
 @parametrize_models()


### PR DESCRIPTION
This was originally supposed to be faster, but it turns out to be slower on small problem sizes. The main advantage is a significantly smaller memory footprint, which leads to a faster evaluation time on large instances (bond dimension of ~100, sequences of length ~1000). This slimmer eval method can be forced by using the keyword `fast_eval=False` when calling the Prob*MPS forward methods.